### PR TITLE
change apt-get to gnupg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ brew install gpg2
 #### Linux
 
 ```
-apt-get install gnupg
+apt-get install gnupg2
 ```
 
 Once gpg has been installed generate a signing key:


### PR DESCRIPTION
it was required for --quick-gen-key and also gets aligned with the one installed in the image-signature-webhook image.